### PR TITLE
[EN-267] Fix Payload Auth Plug-in Login with Auth0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@papercup/payload-auth-plugin",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "author": "Papercup <claudiu@papercup.com>",
   "type": "module",
   "license": "MIT",

--- a/src/core/session/payload.ts
+++ b/src/core/session/payload.ts
@@ -1,150 +1,153 @@
-import { BasePayload, getCookieExpiration } from 'payload'
-import { UserNotFound } from '../error'
+import {BasePayload, getCookieExpiration} from 'payload'
+import {UserNotFound} from '../error'
 import jwt from 'jsonwebtoken'
-import { OAuthAccountInfo } from '../../types'
-import { generate } from "generate-password";
+import {OAuthAccountInfo} from '../../types'
+import {generate} from "generate-password";
 
 type Collections = {
-  usersCollectionSlug: string
-  accountsCollectionSlug: string
+    usersCollectionSlug: string
+    accountsCollectionSlug: string
 }
 
 export class PayloadSession {
-  readonly #collections: Collections
-  readonly #successPath: string = '/admin'
-  constructor(collections: Collections) {
-    this.#collections = collections
-  }
-  async #upsertAccount(
-      oauthAccountInfo: OAuthAccountInfo,
-      scope: string,
-      issuerName: string,
-      payload: BasePayload,
-      expectedRoles?: string[]
-  ) {
-    let userID: string = ''
+    readonly #collections: Collections
+    readonly #successPath: string = '/admin'
 
-    // first we check if the user already exists in the users collection
-    const findUsersResult = await payload.find({
-      collection: this.#collections.usersCollectionSlug,
-      where: {
-        email: {
-          equals: oauthAccountInfo.email,
-        },
-      },
-    })
-
-    const userFound = findUsersResult.docs.length > 0;
-    const auth0AccountInfoHasAnyExpectedRole = oauthAccountInfo.roles && oauthAccountInfo.roles.some((role) => expectedRoles?.includes(role));
-    if (userFound) {
-      // if the user exists, wee assign the userID to the first user found
-      userID = findUsersResult.docs[0].id as string
-    } else if (auth0AccountInfoHasAnyExpectedRole) {
-      // if the user doesn't exist, we create a new user if the user has an expected role
-      const user = await payload.create({
-        collection: "users",
-        data: {
-          email: oauthAccountInfo.email,
-          password: generate({
-            length: 32,
-            numbers: true,
-            symbols: true,
-            lowercase: true,
-            uppercase: true,
-            strict: true,
-          }),
-        },
-      });
-      userID = user.id as string
-    } else {
-      // if the user doesn't exist and doesn't have the expected role, we throw an error
-      throw new UserNotFound()
+    constructor(collections: Collections) {
+        this.#collections = collections
     }
 
-    const accounts = await payload.find({
-      collection: this.#collections.accountsCollectionSlug,
-      where: {
-        sub: { equals: oauthAccountInfo.sub },
-      },
-    })
+    async #upsertAccount(
+        oauthAccountInfo: OAuthAccountInfo,
+        scope: string,
+        issuerName: string,
+        payload: BasePayload,
+        expectedRoles?: string[]
+    ) {
+        let userID: string = ''
 
-    if (accounts.docs.length > 0) {
-      await payload.update({
-        collection: this.#collections.accountsCollectionSlug,
-        where: {
-          id: {
-            equals: accounts.docs[0].id,
-          },
-        },
-        data: {
-          scope,
-          name: oauthAccountInfo.name,
-          picture: oauthAccountInfo.picture,
-          roles: oauthAccountInfo.roles,
-        },
-      })
-    } else {
-      await payload.create({
-        collection: this.#collections.accountsCollectionSlug,
-        data: {
-          sub: oauthAccountInfo.sub,
-          issuerName,
-          scope,
-          name: oauthAccountInfo.name,
-          picture: oauthAccountInfo.picture,
-          user: userID,
-          roles: oauthAccountInfo.roles,
-        },
-      })
+        // first we check if the user already exists in the users collection
+        const findUsersResult = await payload.find({
+            collection: this.#collections.usersCollectionSlug,
+            where: {
+                email: {
+                    equals: oauthAccountInfo.email,
+                },
+            },
+        })
+
+        const userFound = findUsersResult.docs.length > 0;
+        const auth0AccountInfoHasAnyExpectedRole = oauthAccountInfo.roles && oauthAccountInfo.roles.some((role) => expectedRoles?.includes(role));
+        if (userFound) {
+            // if the user exists, wee assign the userID to the first user found
+            userID = findUsersResult.docs[0].id as string
+        } else if (auth0AccountInfoHasAnyExpectedRole) {
+            // if the user doesn't exist, we create a new user if the user has an expected role
+            const user = await payload.create({
+                collection: "users",
+                data: {
+                    email: oauthAccountInfo.email,
+                    password: generate({
+                        length: 32,
+                        numbers: true,
+                        symbols: true,
+                        lowercase: true,
+                        uppercase: true,
+                        strict: true,
+                    }),
+                },
+            });
+            userID = user.id as string
+        } else {
+            // if the user doesn't exist and doesn't have the expected role, we throw an error
+            throw new UserNotFound()
+        }
+
+        const accounts = await payload.find({
+            collection: this.#collections.accountsCollectionSlug,
+            where: {
+                sub: {equals: oauthAccountInfo.sub},
+            },
+        })
+
+        if (accounts.docs.length > 0) {
+            await payload.update({
+                collection: this.#collections.accountsCollectionSlug,
+                where: {
+                    id: {
+                        equals: accounts.docs[0].id,
+                    },
+                },
+                data: {
+                    scope,
+                    name: oauthAccountInfo.name,
+                    picture: oauthAccountInfo.picture,
+                    roles: oauthAccountInfo.roles,
+                },
+            })
+        } else {
+            await payload.create({
+                collection: this.#collections.accountsCollectionSlug,
+                data: {
+                    sub: oauthAccountInfo.sub,
+                    issuerName,
+                    scope,
+                    name: oauthAccountInfo.name,
+                    picture: oauthAccountInfo.picture,
+                    user: userID,
+                    roles: oauthAccountInfo.roles,
+                },
+            })
+        }
+        return userID
     }
-    return userID
-  }
-  async createSession(
-    oauthAccountInfo: OAuthAccountInfo,
-    scope: string,
-    issuerName: string,
-    payload: BasePayload,
-    expectedRoles?: string[]
-  ) {
-    const userID = await this.#upsertAccount(oauthAccountInfo, scope, issuerName, payload, expectedRoles)
 
-    const fieldsToSign = {
-      id: userID,
-      email: oauthAccountInfo.email,
-      collection: this.#collections.usersCollectionSlug,
+    async createSession(
+        oauthAccountInfo: OAuthAccountInfo,
+        scope: string,
+        issuerName: string,
+        payload: BasePayload,
+        expectedRoles?: string[]
+    ) {
+        const userID = await this.#upsertAccount(oauthAccountInfo, scope, issuerName, payload, expectedRoles)
+
+        const fieldsToSign = {
+            id: userID,
+            email: oauthAccountInfo.email,
+            collection: this.#collections.usersCollectionSlug,
+        }
+
+        const cookieExpiration = getCookieExpiration({
+            seconds: 7200,
+        })
+
+        const token = jwt.sign(fieldsToSign, payload.secret, {
+            expiresIn: new Date(cookieExpiration).getTime(),
+        })
+
+        const cookies: string[] = []
+        cookies.push(
+            `${payload.config.cookiePrefix!}-token=${token};Path=/;HttpOnly;SameSite=lax;Expires=${cookieExpiration.toString()}`,
+        )
+        const expired = 'Thu, 01 Jan 1970 00:00:00 GMT'
+        cookies.push(`__session-oauth-state=; Path=/; HttpOnly; SameSite=Lax; Expires=${expired}`)
+        cookies.push(`__session-oauth-nonce=; Path=/; HttpOnly; SameSite=Lax; Expires=${expired}`)
+        cookies.push(`__session-code-verifier=; Path=/; HttpOnly; SameSite=Lax; Expires=${expired}`)
+        const successURL = new URL(process.env.AUTH_BASE_URL as string)
+        successURL.pathname = this.#successPath
+        successURL.search = ''
+
+        const res = new Response(null, {
+            status: 302,
+            headers: {
+                Location: successURL.href,
+            },
+        })
+
+        cookies.forEach(cookie => {
+            res.headers.append('Set-Cookie', cookie)
+        })
+
+        return res
     }
-
-    const cookieExpiration = getCookieExpiration({
-      seconds: 7200,
-    })
-
-    const token = jwt.sign(fieldsToSign, payload.secret, {
-      expiresIn: new Date(cookieExpiration).getTime(),
-    })
-
-    const cookies: string[] = []
-    cookies.push(
-      `${payload.config.cookiePrefix!}-token=${token};Path=/;HttpOnly;SameSite=lax;Expires=${cookieExpiration.toString()}`,
-    )
-    const expired = 'Thu, 01 Jan 1970 00:00:00 GMT'
-    cookies.push(`__session-oauth-state=; Path=/; HttpOnly; SameSite=Lax; Expires=${expired}`)
-    cookies.push(`__session-oauth-nonce=; Path=/; HttpOnly; SameSite=Lax; Expires=${expired}`)
-    cookies.push(`__session-code-verifier=; Path=/; HttpOnly; SameSite=Lax; Expires=${expired}`)
-    const successURL = new URL(process.env.AUTH_BASE_URL as string)
-    successURL.pathname = this.#successPath
-    successURL.search = ''
-
-    const res = new Response(null, {
-      status: 302,
-      headers: {
-        Location: successURL.href,
-      },
-    })
-
-    cookies.forEach(cookie => {
-      res.headers.append('Set-Cookie', cookie)
-    })
-
-    return res
-  }
 }

--- a/src/plugins/admin.ts
+++ b/src/plugins/admin.ts
@@ -31,6 +31,11 @@ interface PluginOptions {
    * Accounts collection admin group
    */
   accountsCollectionAdminGroup?: string
+
+    /*
+        * Expected roles for the user to be created in the users collection
+     */
+    expectedRoles?: string[]
 }
 
 export const adminAuthPlugin =
@@ -55,6 +60,7 @@ export const adminAuthPlugin =
       usersCollectionSlug = 'users',
       accountsCollectionAdminGroup = 'Collections',
       providers,
+        expectedRoles
     } = pluginOptions
 
     const session = new PayloadSession({
@@ -78,7 +84,7 @@ export const adminAuthPlugin =
       ...(config.endpoints ?? []),
       ...endpoints.payloadOAuthEndpoints({
         sessionCallback: (oauthAccountInfo, scope, issuerName, basePayload) =>
-          session.createSession(oauthAccountInfo, scope, issuerName, basePayload),
+          session.createSession(oauthAccountInfo, scope, issuerName, basePayload, expectedRoles),
       }),
     ]
     return config

--- a/src/plugins/admin.ts
+++ b/src/plugins/admin.ts
@@ -1,36 +1,36 @@
-import type { Config, Plugin } from 'payload'
-import { EndpointFactory } from '../core/endpoints'
-import { OAuthProviderConfig } from '../types'
-import { PayloadSession } from '../core/session/payload'
-import { InvalidBaseURL } from '../core/error'
-import { buildAccountsCollection } from '../core/collections/admin/accounts'
-import { mapProviders } from '../providers/utils'
+import type {Config, Plugin} from 'payload'
+import {EndpointFactory} from '../core/endpoints'
+import {OAuthProviderConfig} from '../types'
+import {PayloadSession} from '../core/session/payload'
+import {InvalidBaseURL} from '../core/error'
+import {buildAccountsCollection} from '../core/collections/admin/accounts'
+import {mapProviders} from '../providers/utils'
 
 interface PluginOptions {
-  /* Enable or disable plugin
-   * @default true
-   */
-  enabled?: boolean
-  /*
-   * OAuth Providers
-   */
-  providers: OAuthProviderConfig[]
+    /* Enable or disable plugin
+     * @default true
+     */
+    enabled?: boolean
+    /*
+     * OAuth Providers
+     */
+    providers: OAuthProviderConfig[]
 
-  /*
-   * Accounts collections slug
-   * @default "accounts"
-   */
-  accountsCollectionSlug?: string
-  /*
-   * Users collection slug.
-   * @default "users"
-   */
-  usersCollectionSlug?: string
+    /*
+     * Accounts collections slug
+     * @default "accounts"
+     */
+    accountsCollectionSlug?: string
+    /*
+     * Users collection slug.
+     * @default "users"
+     */
+    usersCollectionSlug?: string
 
-  /*
-   * Accounts collection admin group
-   */
-  accountsCollectionAdminGroup?: string
+    /*
+     * Accounts collection admin group
+     */
+    accountsCollectionAdminGroup?: string
 
     /*
         * Expected roles for the user to be created in the users collection
@@ -39,53 +39,53 @@ interface PluginOptions {
 }
 
 export const adminAuthPlugin =
-  (pluginOptions: PluginOptions): Plugin =>
-  (incomingConfig: Config): Config => {
-    const config = { ...incomingConfig }
+    (pluginOptions: PluginOptions): Plugin =>
+        (incomingConfig: Config): Config => {
+            const config = {...incomingConfig}
 
-    if (pluginOptions.enabled === false) {
-      return config
-    }
+            if (pluginOptions.enabled === false) {
+                return config
+            }
 
-    if (!process.env.AUTH_BASE_URL) {
-      throw new InvalidBaseURL()
-    }
+            if (!process.env.AUTH_BASE_URL) {
+                throw new InvalidBaseURL()
+            }
 
-    config.admin = {
-      ...(config.admin ?? {}),
-    }
+            config.admin = {
+                ...(config.admin ?? {}),
+            }
 
-    const {
-      accountsCollectionSlug = 'accounts',
-      usersCollectionSlug = 'users',
-      accountsCollectionAdminGroup = 'Collections',
-      providers,
-        expectedRoles
-    } = pluginOptions
+            const {
+                accountsCollectionSlug = 'accounts',
+                usersCollectionSlug = 'users',
+                accountsCollectionAdminGroup = 'Collections',
+                providers,
+                expectedRoles
+            } = pluginOptions
 
-    const session = new PayloadSession({
-      accountsCollectionSlug: accountsCollectionSlug,
-      usersCollectionSlug: usersCollectionSlug,
-    })
+            const session = new PayloadSession({
+                accountsCollectionSlug: accountsCollectionSlug,
+                usersCollectionSlug: usersCollectionSlug,
+            })
 
-    const endpoints = new EndpointFactory(mapProviders(providers))
+            const endpoints = new EndpointFactory(mapProviders(providers))
 
-    // Create accounts collection if doesn't exists
-    config.collections = [
-      ...(config.collections ?? []),
-      buildAccountsCollection(
-        accountsCollectionSlug,
-        usersCollectionSlug,
-        accountsCollectionAdminGroup,
-      ),
-    ]
+            // Create accounts collection if doesn't exists
+            config.collections = [
+                ...(config.collections ?? []),
+                buildAccountsCollection(
+                    accountsCollectionSlug,
+                    usersCollectionSlug,
+                    accountsCollectionAdminGroup,
+                ),
+            ]
 
-    config.endpoints = [
-      ...(config.endpoints ?? []),
-      ...endpoints.payloadOAuthEndpoints({
-        sessionCallback: (oauthAccountInfo, scope, issuerName, basePayload) =>
-          session.createSession(oauthAccountInfo, scope, issuerName, basePayload, expectedRoles),
-      }),
-    ]
-    return config
-  }
+            config.endpoints = [
+                ...(config.endpoints ?? []),
+                ...endpoints.payloadOAuthEndpoints({
+                    sessionCallback: (oauthAccountInfo, scope, issuerName, basePayload) =>
+                        session.createSession(oauthAccountInfo, scope, issuerName, basePayload, expectedRoles),
+                }),
+            ]
+            return config
+        }


### PR DESCRIPTION
This pull request introduces a new feature to enforce role-based user creation during OAuth authentication, along with a minor version bump. The most significant changes include adding support for expected roles in the `PayloadSession` class, updating the plugin options to include `expectedRoles`, and integrating this functionality into the `adminAuthPlugin`.

### Feature: Role-based user creation during OAuth authentication
* [`src/core/session/payload.ts`](diffhunk://#diff-20bf7b0000796b88a9033efc780334eb72e01bdcb68fd66c3151bece0a7dbe72R15-R30): Updated the `PayloadSession` class to include an `expectedRoles` parameter in the `#upsertAccount` and `createSession` methods. This ensures that users are only created if their roles match the expected roles. A new user is created with a generated password if they meet the role criteria; otherwise, an error is thrown. [[1]](diffhunk://#diff-20bf7b0000796b88a9033efc780334eb72e01bdcb68fd66c3151bece0a7dbe72R15-R30) [[2]](diffhunk://#diff-20bf7b0000796b88a9033efc780334eb72e01bdcb68fd66c3151bece0a7dbe72L34-L37) [[3]](diffhunk://#diff-20bf7b0000796b88a9033efc780334eb72e01bdcb68fd66c3151bece0a7dbe72R104-R112)
* [`src/plugins/admin.ts`](diffhunk://#diff-6f530f4d397a28ef345bac0fa29cbbd7e3d3e482d6f3f512d18243e05a51912bR34-R38): Added `expectedRoles` to the `PluginOptions` interface and passed it to the `PayloadSession` instance. Integrated the `expectedRoles` parameter into the `session.createSession` call to enforce role-based user creation. [[1]](diffhunk://#diff-6f530f4d397a28ef345bac0fa29cbbd7e3d3e482d6f3f512d18243e05a51912bR34-R38) [[2]](diffhunk://#diff-6f530f4d397a28ef345bac0fa29cbbd7e3d3e482d6f3f512d18243e05a51912bR63) [[3]](diffhunk://#diff-6f530f4d397a28ef345bac0fa29cbbd7e3d3e482d6f3f512d18243e05a51912bL81-R87)

### Dependency management
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Incremented the package version from `0.6.4` to `0.6.5`.